### PR TITLE
Add skill-audit-mcp to Open Source Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome open-source tools, resources, and tutorials for MLSecO
 | [Agentic Security](https://github.com/msoedov/agentic_security)| Agentic LLM Vulnerability Scanner / AI red teaming kit|
 | [CircleGuardBench](https://github.com/whitecircle-ai/circle-guard-bench)| A full-fledged benchmark for evaluating protection capabilities of AI models|
 | [Promptfoo Scanner](https://github.com/promptfoo/promptfoo) | An open-source LLM red teaming tool |
+| [skill-audit-mcp](https://github.com/eltociear/skill-audit-mcp) | Static security scanner for MCP servers, AI agent skills, and plugins. Detects 68 attack patterns across CRITICAL/HIGH/MEDIUM/LOW — credential exfiltration, prompt injection, code execution, seed-phrase harvesting, auth bypass, path traversal. SARIF output, GitHub Action, multi-arch Docker image |
 
 
 ## Commercial Tools


### PR DESCRIPTION
Adds [skill-audit-mcp](https://github.com/eltociear/skill-audit-mcp) to the **Open Source Security Tools** table.

Static security scanner for the **MCP server / AI agent skill layer**. Where most tools in this list test models adversarially, skill-audit-mcp scans the tool definitions and skill files themselves — the layer where production prompt-injection and credential-exfiltration attacks actually ship.

**Detects 68 attack patterns across CRITICAL/HIGH/MEDIUM/LOW:**

- credential exfiltration / seed-phrase harvest
- prompt injection (instruction override, role hijack, hidden Unicode, encoded payloads)
- arbitrary code execution
- auth bypass / identity impersonation
- path traversal

**Distribution:**
- GitHub Action: `uses: eltociear/skill-audit-mcp@v1` → SARIF → GitHub Code Scanning
- Multi-arch Docker: `ghcr.io/eltociear/skill-audit-mcp:v1`
- MCP server (three tools: `audit`, `audit_file`, `audit_directory`)
- Hosted x402 API: pay-per-scan USDC micropayments on Base

Zero dependencies, Python 3.6+, MIT, Glama-verified.