### PR TITLE
Add AI-Scan-Interceptor (prompt DLP gateway) to Open Source Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome open-source tools, resources, and tutorials for MLSecO
 | [Agentic Security](https://github.com/msoedov/agentic_security)| Agentic LLM Vulnerability Scanner / AI red teaming kit|
 | [CircleGuardBench](https://github.com/whitecircle-ai/circle-guard-bench)| A full-fledged benchmark for evaluating protection capabilities of AI models|
 | [Promptfoo Scanner](https://github.com/promptfoo/promptfoo) | An open-source LLM red teaming tool |
+| [AI-Scan-Interceptor](https://github.com/mshirakawa-ssp/ai-scan-interceptor) | Self-hostable DLP gateway for enterprise prompts to ChatGPT/Claude/Gemini (Squid + Go ICAP + mTLS, AGPL-3.0) |
 
 
 ## Commercial Tools
@@ -414,6 +415,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ---
 
 <p align="center">Made with ❤️</p>
+
 
 
 


### PR DESCRIPTION
Adding **AI-Scan-Interceptor** to the Open Source Security Tools table.

AI-Scan-Interceptor is a self-hostable DLP gateway that inspects and controls prompts sent from enterprise networks to ChatGPT, Claude, and Gemini. It is implemented as a Squid forward proxy with a Go-based ICAP policy engine and mTLS endpoint identity, deployable via Docker Compose.

- Repo: https://github.com/mshirakawa-ssp/ai-scan-interceptor
- License: AGPL-3.0

In an MLSecOps context, it can complement model-level / artifact-level tools (ModelScan, NB Defense, etc.) by sitting at the network egress, useful for organizations that want to enforce policy on developer/employee use of external LLM services.

Thanks for maintaining this list.