### PR TITLE
Add AIsbom to Open Source Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome open-source tools, resources, and tutorials for MLSecO
 | [Agentic Security](https://github.com/msoedov/agentic_security)| Agentic LLM Vulnerability Scanner / AI red teaming kit|
 | [CircleGuardBench](https://github.com/whitecircle-ai/circle-guard-bench)| A full-fledged benchmark for evaluating protection capabilities of AI models|
 | [Promptfoo Scanner](https://github.com/promptfoo/promptfoo) | An open-source LLM red teaming tool |
+| [AIsbom](https://github.com/Lab700xOrg/aisbom) | Disassembles Pickle bytecode and parses SafeTensors/GGUF binary headers to detect malware and license risks in ML model files before load. Generates CycloneDX/SPDX SBOMs. |
 
 
 ## Commercial Tools


### PR DESCRIPTION
This PR adds [AIsbom](https://github.com/Lab700xOrg/aisbom) to the Open Source Security Tools table.

**What it is:** Open-source CLI (Apache 2.0) that disassembles Python Pickle bytecode and parses SafeTensors / GGUF binary headers to detect malware payloads (RCE-capable globals like `os.system`, `subprocess.Popen`, `eval`) and license risks (non-commercial weights, hidden header licenses) inside ML model files - without loading the model into memory.

**Closest analog in this list:** ModelScan. AIsbom differs in three ways:
1. **Three model formats supported** - Pickle (`.pt` / `.pth` / `.pkl`), SafeTensors, and GGUF.
2. **Remote scanning over HTTP Range requests** - `aisbom scan hf://google-bert/bert-base-uncased` works without downloading the weights to disk.
3. **Standard SBOM output** - CycloneDX v1.6 and SPDX 2.3, so it slots into existing supply-chain pipelines.

**Also ships:**
- [GitHub Action on the Marketplace](https://github.com/marketplace/actions/aisbom-security-scanner) that posts idempotent PR comments.
- Weekly public [advisories page](https://aisbom.io/advisories) scanning the top 50 Hugging Face text-generation models.

Thanks for maintaining this list!