### PR TITLE
Add OWASP Agent Memory Guard to Open Source Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome open-source tools, resources, and tutorials for MLSecO
 | [Privacy Meter](https://github.com/privacytrustlab/ml_privacy_meter) | An open-source library to audit data privacy in statistical and machine learning algorithms|
 | [TensorFlow Model Analysis](https://github.com/tensorflow/model-analysis) | A library for analyzing, validating, and monitoring machine learning models in production|
 | [PromptInject](https://github.com/agencyenterprise/PromptInject) | A framework that assembles adversarial prompts|
+| [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | Official OWASP runtime defense layer that screens AI agent memory reads/writes, blocking prompt injection, secret leakage, and memory poisoning (ASI06) |
 | [TextAttack](https://github.com/QData/TextAttack) | TextAttack is a Python framework for adversarial attacks, data augmentation, and model training in NLP|
 | [OpenAttack](https://github.com/thunlp/OpenAttack) | An Open-Source Package for Textual Adversarial Attack|
 | [TextFooler](https://github.com/jind11/TextFooler) | A Model for Natural Language Attack on Text Classification and Inference|


### PR DESCRIPTION
## Description

Adds [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) to the Open Source Security Tools table.

Agent Memory Guard is the official OWASP runtime defense layer for AI agent memory. It screens every read/write operation to agent memory stores, blocking prompt injection, secret leakage, and memory poisoning attacks.

**Why it belongs here:**
- Official OWASP project (reference implementation for OWASP Top 10 Agentic ASI06)
- Addresses a unique gap: runtime memory security for AI agents
- Integrations for LangChain, LlamaIndex, CrewAI, and AutoGen
- 3,000+ PyPI downloads
- Active development with CI/CD pipeline