### PR TITLE
Add Future AGI Protect

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A curated list of awesome open-source tools, resources, and tutorials for MLSecO
 | [Agentic Security](https://github.com/msoedov/agentic_security)| Agentic LLM Vulnerability Scanner / AI red teaming kit|
 | [CircleGuardBench](https://github.com/whitecircle-ai/circle-guard-bench)| A full-fledged benchmark for evaluating protection capabilities of AI models|
 | [Promptfoo Scanner](https://github.com/promptfoo/promptfoo) | An open-source LLM red teaming tool |
+| [Future AGI Protect](https://github.com/future-agi/future-agi) | Multimodal guardrails detecting prompt injection, jailbreak, PII, and toxicity across text, image, and audio |
 
 
 ## Commercial Tools


### PR DESCRIPTION
This PR adds Future AGI to this list in the **Open Source Security Tools** section.

[Future AGI Protect](https://github.com/future-agi/future-agi) is the open-source (Apache-2.0), self-hostable guardrails layer of Future AGI: runtime detection of jailbreak, prompt injection, PII, and toxicity across text, image, and audio.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.