### PR TITLE
Add IronClaw to Open Source Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A curated list of awesome open-source tools, resources, and tutorials for MLSecO
 | [TrustGate](https://github.com/NeuralTrust/TrustGate) | An open-source Generative Application Firewall (GAF) |
 | [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) | Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling |
 | [Whistleblower](https://github.com/Repello-AI/whistleblower) | Open-source offensive tool by Repello AI for testing LLM apps against system prompt leakage |
+| [IronClaw](https://github.com/IronSecCo/ironclaw) | Security-hardened, self-hosted runtime that sandboxes autonomous AI agents in a gVisor (runsc) sandbox with network=none, a read-only rootfs, host-side credential injection, and a human-approval gateway; signed and attested supply chain (cosign, SLSA, SBOMs) |
 
 
 ## Commercial Tools


### PR DESCRIPTION
Adds [IronClaw](https://github.com/IronSecCo/ironclaw) to the **Open Source Security Tools** table.

IronClaw is an AGPLv3 + commercial, self-hosted runtime for autonomous AI agents built to contain a compromised agent: each agent runs in a per-conversation gVisor (`runsc`) sandbox with `network=none`, a read-only rootfs, and dropped capabilities; provider keys are injected host-side and never enter the box; every capability change is held at a human-approval gateway; and the supply chain is signed and attested (cosign, SLSA provenance, SBOMs).

Single table row, matches the section's `| [Tool](url) | Description |` format.