### PR TITLE
Add Redcells to Open Source Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of awesome open-source tools, resources, and tutorials for MLSecO
 | [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) | Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling |
 | [Whistleblower](https://github.com/Repello-AI/whistleblower) | Open-source offensive tool by Repello AI for testing LLM apps against system prompt leakage |
 | [IronClaw](https://github.com/IronSecCo/ironclaw) | Security-hardened, self-hosted runtime that sandboxes autonomous AI agents in a gVisor (runsc) sandbox with network=none, a read-only rootfs, host-side credential injection, and a human-approval gateway; signed and attested supply chain (cosign, SLSA, SBOMs) |
+| [Redcells](https://redcells.net) | Automated adversarial testing for OpenAI-compatible language models. Submit a target model and an intent (prompt injection, jailbreak, data leakage), and it runs an iterative attack→refine pipeline with per-layer prompts, responses, and judge scores. API-first with dashboard, encrypted target credentials, rate limiting, and Stripe billing. |
 
 
 ## Commercial Tools


### PR DESCRIPTION
This PR adds Redcells to the Open Source Security Tools section.

Redcells is an automated adversarial testing platform for OpenAI-compatible LLMs. It runs structured red-team jobs with an iterative attack-to-refine pipeline and surfaces per-layer prompts, responses, and judge scores in a dashboard and API.

- Homepage: https://redcells.net
- Repo: https://github.com/awdemos/redcell

Thanks for maintaining this list!