### PR TITLE
Add crossguard-py to LLM Security and Red Teaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ LLM security and red-teaming tools test prompts, model behavior, application con
 
 | Tool | Description |
 |------|-------------|
+| [CrossGuard AI](https://github.com/crossguard-ai/crossguard-py) | Image sanitizer that destroys steganographic prompt-injection payloads embedded via LSB, DCT coefficients, or EXIF metadata before images reach a multimodal model. |
 | [Garak](https://github.com/NVIDIA/garak) | LLM vulnerability scanner |
 | [Promptfoo Scanner](https://github.com/promptfoo/promptfoo) | An open-source LLM red teaming tool |
 


### PR DESCRIPTION
> [!IMPORTANT]
> Read the [contribution guidelines](./CONTRIBUTING.md) before submitting.
> Awesome MLSecOps is a curated technical resource, not a product directory.

## Submission

- **Resource:** crossguard-py
- **Canonical URL:** https://github.com/crossguard-ai/crossguard-py
- **Suggested section:** Open Source Security Tools > LLM Security and Red Teaming
- **Project launch date:** 2026-07-05

## MLSecOps relevance

**Security problem.** Prompt-injection defenses generally guard the text channel and treat an attached image as inert data. For a multimodal model it is not inert. Instructions can be embedded in an image so that the model reads them and a human reviewer sees nothing, using least-significant-bit steganography, DCT-coefficient embedding that survives JPEG recompression, or EXIF metadata. CSA and IEEE both published systematic studies of image-based prompt injection in 2026 measuring steganographic attack success at 24.3% across GPT-4V, Claude, and LLaVA, and up to 64% in stealth-constrained configurations. That literature is almost entirely attack-side.

**Protected component.** Application and pipeline. Specifically the image-ingest path of any LLM application accepting user-supplied images.

**Threat coverage.** Steganographic prompt injection via LSB (spatial domain), DCT coefficients (frequency domain), and EXIF metadata. The approach destroys the carrier channel rather than detecting the payload, so it does not depend on recognising the encoding the attacker chose. Adversarial pixel perturbations are explicitly out of scope and documented as such in the README, the benchmark, and SECURITY.md rather than left implied.

**Evaluation method.** 108,015 samples. Per-sample results ship in the repository under `benchmarks/2026-07-06_layer1_108k/`, so the headline figure is recountable rather than asserted, and the reproduction command is in the benchmark README. Ground truth is verifiable rather than claimed: the real stego covers have a zeroed LSB plane, so the 1-bits are the payload, and destruction is measured as residual payload correlation P(after=1|before=1) minus P(after=1|before=0) below 0.10, which is independent of base rate. Sources are the Kaggle Stego-Images dataset plus BOSSBase and ALASKA#2 covers. Measured costs are stated up front rather than buried: mean output SSIM 0.925 so it is not visually lossless, single-image latency roughly 110 to 145ms at 512px, and roughly 1.0% of samples unscored and excluded from the denominator rather than counted as successes.

## Affiliation

- [ ] I have no material affiliation with this resource.
- [x] I am affiliated with this resource.

If affiliated, describe the relationship: I am the author and maintainer. No commercial relationship, no funding, no paid tier.

## Checklist

- [x] I have read and followed the [contribution guidelines](./CONTRIBUTING.md).
- [x] The resource addresses a concrete MLSecOps or AI-security problem.
- [x] The resource is publicly usable or independently evaluable.
- [x] The description is factual, neutral, and one sentence long.
- [x] The canonical URL contains no referral or tracking parameters.
- [x] This PR proposes one resource or one focused change.
- [x] I have disclosed all relevant affiliations.

## Maturity note

Flagging this against the 90-day rule rather than hoping it goes unnoticed. First commit was 2026-07-05, so this is 21 days old and I recognise it may be deferred. Offering the early-stage evidence the guidelines list: an MIT-licensed tagged release (v0.1.0), reproducible results across 108,015 samples with per-sample artifacts and a published reproduction command, 123 passing tests, a security-reporting process in SECURITY.md that names sanitizer bypass as the highest severity class, a documented pre-release audit that found and fixed two critical defects, and a published negative result where an attempted improvement failed and is reported as a failure rather than omitted. There are no independent users yet. If deferral is the correct call I have no objection and will resubmit once there is adoption evidence.

Technical review: Reviewed 2026-07-26. Evidence checked: https://github.com/crossguard-ai/crossguard-py (README, MIT LICENSE, SECURITY.md), https://github.com/crossguard-ai/crossguard-py/releases/tag/v0.1.0, and benchmarks/2026-07-06_layer1_108k/README.md.