### PR TITLE
Add trentclaw to Open Source Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ AI agent security tools assess memory, tools, permissions, workflows, and runtim
 |------|-------------|
 | [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | OWASP project providing a runtime defense layer that screens AI agent memory reads and writes against prompt injection, secret leakage, and memory poisoning |
 | [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) | Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling |
+| [trentclaw](https://github.com/trnt-ai/trent-openclaw-security-assessment) | Apache-2.0 scanner that assesses OpenClaw agent environments, covering gateway configuration, tool permissions, MCP servers, plugins, and chained attack paths |
 
 ### Privacy-Preserving Machine Learning
 


### PR DESCRIPTION
trentclaw runs inside the OpenClaw session and scans the environment it is installed in: the skills you have installed, the runtime configuration, and access risks, reporting what a security engineer would flag.

Technical review: Reviewed 2026-08-02. Evidence checked: repository README, Apache-2.0 license, release history (active since March 2026).

**Disclosure:** I am affiliated with this project as an employee. I work on Trent.

> [!IMPORTANT]
> Read the [contribution guidelines](./CONTRIBUTING.md) before submitting.
> Awesome MLSecOps is a curated technical resource, not a product directory.

## Submission

- **Resource:** trentclaw (OpenClaw security assessment skill)
- **Canonical URL:** https://github.com/trnt-ai/trent-openclaw-security-assessment
- **Suggested section:** Tools
- **Project launch date:** March 2026

## MLSecOps relevance

Security problem: OpenClaw agent runtimes execute third-party skills with broad permissions, so a malicious or vulnerable skill, or a misconfigured runtime, exposes the host environment and its credentials. Protected component: the OpenClaw runtime itself, covering installed skills, runtime configuration, and access risks. Threat coverage: skill supply chain risk and configuration and access weaknesses, assessed from inside the session rather than from an external scanner. Evaluation method: open source under Apache-2.0 and independently runnable (install from ClawHub and inspect the source); the underlying skill scanning has a published benchmark against the 2,354 most-downloaded ClawHub skills.

## Affiliation

- [ ] I have no material affiliation with this resource.
- [ x] I am affiliated with this resource.

If affiliated, describe the relationship:

## Checklist

- [ x] I have read and followed the [contribution guidelines](./CONTRIBUTING.md).
- [ x] The resource addresses a concrete MLSecOps or AI-security problem.
- [ x] The resource is publicly usable or independently evaluable.
- [ x] The description is factual, neutral, and one sentence long.
- [ x] The canonical URL contains no referral or tracking parameters.
- [ x] This PR proposes one resource or one focused change.
- [ x] I have disclosed all relevant affiliations.