### PR TITLE
Add Norviq to AI Agent Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ AI agent security tools assess memory, tools, permissions, workflows, and runtim
 |------|-------------|
 | [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | OWASP project providing a runtime defense layer that screens AI agent memory reads and writes against prompt injection, secret leakage, and memory poisoning |
 | [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) | Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling |
+| [Norviq](https://github.com/norviq-dev/norviq) | Apache-2.0 policy enforcement point for MCP tool calls, shipping in audit mode, that content-hash pins tool definitions at discovery and evaluates an OPA/Rego policy on each invocation |
 
 ### Privacy-Preserving Machine Learning
 


### PR DESCRIPTION
Adds one row to the **AI Agent Security** table, after `Agent-Wiz`.

**Disclosure:** I maintain this project.

| Field | Information |
|---|---|
| Security use case | Policy enforcement at the MCP client-server boundary: pinning tool definitions at discovery, and evaluating an OPA/Rego policy on every `tools/call`. The shipped baseline runs in audit mode — the decision is recorded and the call proceeds. |
| Protected component | The agent's tool-calling path. Runs two ways: a local proxy wrapping an MCP server command, or a Kubernetes install (control plane, mutating admission webhook, injected sidecars). |
| Threat coverage | MCP rug pulls and tool poisoning (OWASP MCP03:2025), where a server serves a different tool definition than the one approved, including via `notifications/tools/list_changed`. The attack class was documented by Invariant Labs and Trail of Bits in April 2025. Gate A scans tool definitions for injection patterns and content-hash pins six fields per tool (`name`, `title`, `description`, `inputSchema`, `outputSchema`, `annotations`) as canonical JSON. Gate B evaluates a policy per invocation; a refusal is answered locally so the server never executes the call. |
| Evaluation | Source, tests and Helm chart in the repo; wheel published (`pip install norviq`, 0.2.5). The pinning path can be exercised end to end against any MCP server with `NRVQ_MCP_PIN_STORE=file` and `NRVQ_MCP_PIN_PATH` set. Write-up with the measurements: https://norviq.dev/blog/the-mcp-server-you-approved/ |
| Maturity | Created 2026-05-28; Apache-2.0; release 0.2.5 on PyPI; single maintainer; 1 GitHub star and no organizational adopters I am aware of. |

**Limitations, stated because the row should not read as more than it is:**

- It ships in audit mode. The Kubernetes install brings up its strict baseline in `audit`, which records what it would have refused and lets the call proceed.
- Gate A is a heuristic and evadable by construction — the module docstring says so. Payloads measured scanning clean: base64, ROT13, the path spelled out in words, Spanish, German. Three `test_known_evasion_*` tests assert it fails.
- Pinning is trust-on-first-use and keyed on tool name. A rename (`send_email_v2`) defeats it, and drift is caught only on the next re-read of `tools/list`.
- Gate B falls open. All three shipped presets default to `allow`; with no control plane reachable the call is forwarded and logged `engine_unavailable_fallback`.
- `pip install norviq` alone does not stop the attack the write-up describes; that needs both environment variables above.

Happy to move it to another section if the categorisation reads differently to you.
