### PR TITLE
Add Prismor to AI Agent Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ AI agent security tools assess memory, tools, permissions, workflows, and runtim
 |------|-------------|
 | [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | OWASP project providing a runtime defense layer that screens AI agent memory reads and writes against prompt injection, secret leakage, and memory poisoning |
 | [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) | Python CLI by Repello AI for extracting agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and running automated threat modeling |
+| [Prismor](https://github.com/PrismorSec/prismor) | Self-hosted runtime control plane that screens AI coding-agent tool calls against a signed policy before execution, blocking or routing to human approval secret exfiltration, prompt-injection-driven actions, and destructive commands across Claude Code, Codex, and MCP servers |
 
 ### Privacy-Preserving Machine Learning
 


### PR DESCRIPTION
Adds [Prismor](https://github.com/PrismorSec/prismor) to **Open Source Security Tools → AI Agent Security**, placed after Agent-Wiz to keep the table alphabetical. One entry, one line, no other changes.

| Field | Details |
|---|---|
| Security use case | Runtime policy enforcement on AI-agent tool calls: every tool call (shell, file, network, MCP) is screened against a signed policy before execution and is allowed, redacted, routed to human approval, or blocked. |
| Protected component | AI agents and the developer machine / repo they act on — data (secrets, PII), local filesystem, shell, and MCP servers. |
| Threat coverage | Secret and credential exfiltration, prompt-injection-driven tool use and poisoned tool results, excessive agency, destructive commands, unsanctioned network egress, and MCP/supply-chain risk. Maps to OWASP Agentic Top 10 (ASI01-ASI10). |
| Evaluation | `pip install prismor && prismor setup` wires the hooks into Claude Code / Codex; policy lives in a readable YAML and `prismor status` / the local dashboard show every decision. Docs: https://github.com/PrismorSec/prismor/tree/main/docs |
| Maturity | Public since 2026-02-20 (>6 months), Apache-2.0, 336 stars, 83 tagged releases, the latest [v1.44.0](https://github.com/PrismorSec/prismor/releases/tag/v1.44.0) on 2026-08-27, actively maintained — reproducible commit [`23439e6`](https://github.com/PrismorSec/prismor/commit/23439e628123a34deceec21334a8a4a33a96ac58) (2026-08-29). CI runs the security-regression suite on Linux and Windows. |
| Affiliation | See disclosure below. |

> **Disclosure:** I am affiliated with this project as its author and maintainer.

> **Technical review:** Reviewed 2026-08-29. Evidence checked: canonical repository https://github.com/PrismorSec/prismor, Apache-2.0 license, release v1.44.0, commit 23439e628123a34deceec21334a8a4a33a96ac58, and the first-party docs under `docs/`.
