### PR TITLE
Add Provael to Adversarial Machine Learning Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Adversarial machine learning testing tools evaluate model robustness against eva
 |------|-------------|
 | [Adversarial Robustness Toolbox](https://github.com/IBM/adversarial-robustness-toolbox) | Library of defense methods for ML models against adversarial attacks |
 | [Foolbox](https://github.com/bethgelab/foolbox) | Python toolbox for creating and evaluating adversarial attacks and defenses |
+| [Provael](https://github.com/provael/provael) | Adversarial testing for vision-language-action robot policies in simulation; reports attack success rate with a 95% Wilson interval against a benign-control false-positive floor |
 
 ### LLM Security and Red Teaming
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ Adversarial machine learning testing tools evaluate model robustness against eva
 |------|-------------|
 | [Adversarial Robustness Toolbox](https://github.com/IBM/adversarial-robustness-toolbox) | Library of defense methods for ML models against adversarial attacks |
 | [Foolbox](https://github.com/bethgelab/foolbox) | Python toolbox for creating and evaluating adversarial attacks and defenses |
+
+### Embodied AI and Robotics ML Security
+
+Embodied AI and robotics ML security tools test policies that emit actions rather than text, where a successful attack moves a robot out of its safe envelope rather than changing a prediction. Results below are simulation unless a project states otherwise.
+
+| Tool | Description |
+|------|-------------|
+| [BadVLA](https://github.com/Zxy-MLlab/BadVLA) | Backdoor attacks on vision-language-action models via objective-decoupled optimization; reference implementation for the paper |
 | [Provael](https://github.com/provael/provael) | Adversarial testing for vision-language-action robot policies in simulation; reports attack success rate with a 95% Wilson interval against a benign-control false-positive floor |
+| [roboticAttack](https://github.com/William-wAng618/roboticAttack) | Untargeted and targeted adversarial attacks on vision-language-action models; code for "Exploring the Adversarial Vulnerabilities of VLA Models in Robotics" |
 
 ### LLM Security and Red Teaming
 


### PR DESCRIPTION
Adds a third row to **Adversarial Machine Learning Testing**.

## Disclosure

**I am the author and maintainer of this project.** Per CONTRIBUTING's self-promotion section, disclosing that up front. Everything below is independently verifiable from the linked repository, and I have kept the entry wording neutral and factual.

## Why it is a different category from the two existing rows

ART and Foolbox both operate on **classifier outputs** — the failure is a wrong label. This operates on a **control policy**, where the failure predicate is a spatial condition on the actuated state: did the end-effector enter a region it was required to stay out of. Same adversarial-testing discipline, different object, and the reported quantity carries a benign-control floor rather than standing alone.

## Maturity evidence

| | |
|---|---|
| Launch date | 3 June 2026 |
| Releases | 30, latest `v0.39.1` (1 September 2026) |
| Maintenance | active; CI gate of ruff + mypy + 1234 tests on every PR |
| Distribution | PyPI, GitHub Action, pre-commit hook, multi-arch container |
| License | Apache-2.0 |
| Adoption | **low — single-digit stars, no third-party submissions to its leaderboard yet** |

I am stating the adoption signal plainly because CONTRIBUTING says stars are "one adoption signal, not a quality threshold" — so you should have the real number rather than infer it.

## Scope limits, stated rather than buried

- **Simulation only.** Nothing in it has run on a physical robot.
- **One policy measured, on one suite.** SmolVLA × LIBERO.
- **It publishes its nulls.** Two of the three measured attack families scored **0%** against the real model, published at the same prominence as the positive result.

If a young, self-submitted, single-maintainer project does not meet the maturity bar yet, closing this is a reasonable call and I will not re-submit.
